### PR TITLE
Add the hability for each user to use root variables instead of the predefined themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ So a full example would look something like
 `default` `ocean`  `pink`  `dark`
 ![DEV Widget themes](https://res.cloudinary.com/saurabhdaware/image/upload/v1574802681/saurabhdawaretk/dev-widget-2.png)
 
+If you didn't set any theme, and you don't want the default theme, you can create your own using CSS variables in the `:root` selector
+
+```html
+:root {
+    --header-bg: #BEE3F8;
+    --header-color: #424242;
+    --header-logo-filter: invert(50%);
+    --content-bg: #EBF8FF;
+    --content-bghover: #BEE3F8;
+    --content-border: #EBF8FF;
+    --content-color: #2D3748;
+    --button-bg: #E2E8F0;
+    --button-color: #2D3748;
+    --scroll-track: #FFFFFF;
+    --scroll-thumb: #2D3748;
+    --likes-color: #000000;
+    --likes-icon-filter: invert(0%);
+}
+```
+
 ---
 
 ## Changelog

--- a/src/card.component.mjs
+++ b/src/card.component.mjs
@@ -35,10 +35,53 @@ export class DevCard extends HTMLElement{
             this.setWidth();
         }
 
-        if(attr == 'data-theme' && oldValue != newValue && newValue != ''){
+        if(attr == 'data-theme' && oldValue != newValue && newValue != '' && newValue != 'default'){
             this[attr] = newValue;
             this.setTheme(newValue);
+        } else {
+            this.setDefaultVariables();
         }
+    }
+
+    setDefaultVariables() {
+        const defaultColors = [
+            '#111',
+            '#fff',
+            'invert(50%)',
+            '#fff',
+            '#eee',
+            '#ddd',
+            '#222',
+            '#ddd',
+            '#222',
+            '#eee',
+            '#666',
+            '#999'
+        ];
+        const defaultVariables = [
+            '--header-bg',
+            '--header-color',
+            '--header-logo-filter',
+            '--content-bg',
+            '--content-bghover',
+            '--content-border',
+            '--content-color',
+            '--button-bg',
+            '--button-color',
+            '--scroll-track',
+            '--scroll-thumb',
+            '--likes-color'
+        ];
+        defaultVariables.forEach((variable, index) => {
+            if (
+                !getComputedStyle(document.documentElement).getPropertyValue(variable)
+            ) {
+                document.documentElement.style.setProperty(
+                    variable,
+                    defaultColors[index]
+                );
+            }
+        });
     }
 
     connectedCallback(){

--- a/src/card.component.mjs
+++ b/src/card.component.mjs
@@ -54,7 +54,8 @@ export class DevCard extends HTMLElement{
             '#222',
             '#eee',
             '#666',
-            '#999'
+            '#999',
+            'invert(0%)'
         ];
         const defaultVariables = [
             '--header-bg',
@@ -68,7 +69,8 @@ export class DevCard extends HTMLElement{
             '--button-color',
             '--scroll-track',
             '--scroll-thumb',
-            '--likes-color'
+            '--likes-color',
+            '--likes-icon-filter'
         ];
         defaultVariables.forEach((variable, index) => {
             if (

--- a/src/card.component.mjs
+++ b/src/card.component.mjs
@@ -35,11 +35,9 @@ export class DevCard extends HTMLElement{
             this.setWidth();
         }
 
-        if(attr == 'data-theme' && oldValue != newValue && newValue != '' && newValue != 'default'){
+        if(attr == 'data-theme' && oldValue != newValue && newValue != ''){
             this[attr] = newValue;
             this.setTheme(newValue);
-        } else {
-            this.setDefaultVariables();
         }
     }
 
@@ -177,7 +175,10 @@ export class DevCard extends HTMLElement{
             })
     }
 
-    render(){
+    render(){        
+        if(!this.dataset.theme) {
+            this.setDefaultVariables();
+        }
         this.style.display = 'inline-block';
         this.articles = [];
         this.limit = this.dataset.limit || 30;

--- a/src/card.style.mjs
+++ b/src/card.style.mjs
@@ -3,19 +3,7 @@ export const css = // css
 .card{
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     text-align: left;
-    font-family: Arial;
-    --header-bg:#111;
-    --header-color:#fff;
-    --header-logo-filter: invert(50%);
-    --content-bg: #fff;
-    --content-bghover: #eee;
-    --content-border: #ddd;
-    --content-color: #222;
-    --button-bg: #ddd;
-    --button-color: #222;
-    --scroll-track: #eee;
-    --scroll-thumb: #666;
-    --likes-color: #999;
+    font-family: Arial;    
 }
 
 /* DARK THEME */

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,14 @@
 <html>
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DEV Card</title>
-</head>
-<body>
-    <dev-widget data-username="saurabhdaware"></dev-widget>
+  </head>
+  <body>
+    <dev-widget data-username="saurabhdaware" data-theme="default"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="ocean"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="pink"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="dark"></dev-widget>
     <script src="card.component.mjs" type="module"></script>
     <!-- <script src="https://unpkg.com/dev-widget@1.1.0/dist/card.component.min.mjs" type="module"> -->
-</body>
+  </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <title>DEV Card</title>
   </head>
   <body>
-    <dev-widget data-username="saurabhdaware" data-theme="default"></dev-widget>
+    <dev-widget data-username="saurabhdaware"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="ocean"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="pink"></dev-widget>
     <dev-widget data-username="saurabhdaware" data-theme="dark"></dev-widget>


### PR DESCRIPTION
ref #16 

This PR is meant to give the user the ability to set their own theme colors, instead of adding a lot of themes inside the `card.style.mjs`.
The idea right now is, the `card` base class will not longer have any css variables to set the default theme. 
If the theme is set to `default`, then will use the `:root` variables that each user must define in their `<style>`.
If the theme is `default` but the user didn't set a variable that is being expected, then the component will set the default theme as it is right now.
Note that this is a breaking change, since everyone will need to use the theme as `default` because of the observe variables.
I'm opening this as a draft PR and looking for your what do you think of this PR.
Thank you.